### PR TITLE
Added files inside `dist` for packages

### DIFF
--- a/packages/ethers/package.json
+++ b/packages/ethers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/hardhat-ethers",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "license": "MIT",
     "description": "Hardhat Vechain Ethers Plugin",
     "repository": "github:vechainfoundation/hardhat-plugins",
@@ -16,7 +16,7 @@
         "ethers"
     ],
     "files": [
-        "dist",
+        "dist/**",
         "LICENSE",
         "README.md"
     ],

--- a/packages/vechain/package.json
+++ b/packages/vechain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@vechain/hardhat-vechain",
-    "version": "0.1.5",
+    "version": "0.1.7",
     "license": "MIT",
     "description": "Hardhat plugin for a VeChain provider",
     "homepage": "https://github.com/vechainfoundation/hardhat-plugins",
@@ -16,7 +16,7 @@
     ],
     "main": "dist/index.js",
     "files": [
-        "dist",
+        "dist/**",
         "LICENSE",
         "README.md"
     ],


### PR DESCRIPTION
`yarn publish --access public` did not publish successfully in npm registry until this change was done.

Aligning package versions with the ones published.